### PR TITLE
dplyr::lag, dplyr::leadの引数の変更

### DIFF
--- a/chapter2/2-4-1.R
+++ b/chapter2/2-4-1.R
@@ -9,12 +9,12 @@ stats::lag(x, k=12)
 # tsクラス以外のオブジェクトのラグを求めるにはdplyr::lag()を使う
 library(dplyr)
 x <- 1:10
-dplyr::lag(x, k=1)
+dplyr::lag(x, n=1)
 
 # ラグ系列でデータフレームを作成する
 data.frame(x = 1:10) %>%
-  dplyr::mutate(lead=lead(x, k=1)) %>%
-  dplyr::mutate(lag=lag(x, k=1))
+  dplyr::mutate(lead=lead(x, n=1)) %>%
+  dplyr::mutate(lag=lag(x, n=1))
 
 
 # 階差


### PR DESCRIPTION
p.42, 2-4-1.R の `dplyr::lag(x, k=1)` の箇所で以下のエラーが発生するため、引数をkからnに変更しました。

```
> # tsクラス以外のオブジェクトのラグを求めるにはdplyr::lag()を使う
> library(dplyr)
> x <- 1:10
> dplyr::lag(x, k=1)
Error in `dplyr::lag()`:
! `...` must be empty.
✖ Problematic argument:
• k = 1
Run `rlang::last_trace()` to see where the error occurred.
> 
```

こちらで試した環境は以下のとおりです。dplyrは1.1.4を使用しております。

```
> devtools::session_info()
─ Session info ─────────────────────────────────────────────────────────────────────────────────────
 setting  value
 version  R version 4.4.2 (2024-10-31)
 os       macOS Ventura 13.7.3
 system   aarch64, darwin20
 ui       RStudio
 language (EN)
 collate  en_US.UTF-8
 ctype    en_US.UTF-8
 tz       Asia/Tokyo
 date     2025-02-01
 rstudio  2024.12.0+467 Kousa Dogwood (desktop)
 pandoc   NA

─ Packages ─────────────────────────────────────────────────────────────────────────────────────────
 package     * version date (UTC) lib source
 cachem        1.1.0   2024-05-16 [1] CRAN (R 4.4.0)
 cli           3.6.3   2024-06-21 [1] CRAN (R 4.4.0)
 devtools      2.4.5   2022-10-11 [1] CRAN (R 4.4.0)
 digest        0.6.37  2024-08-19 [1] CRAN (R 4.4.1)
 dplyr       * 1.1.4   2023-11-17 [1] CRAN (R 4.4.0)
 ellipsis      0.3.2   2021-04-29 [1] CRAN (R 4.4.1)
 fastmap       1.2.0   2024-05-15 [1] CRAN (R 4.4.0)
 fs            1.6.5   2024-10-30 [1] CRAN (R 4.4.1)
 generics      0.1.3   2022-07-05 [1] CRAN (R 4.4.0)
 glue          1.8.0   2024-09-30 [1] CRAN (R 4.4.1)
 htmltools     0.5.8.1 2024-04-04 [1] CRAN (R 4.4.0)
 htmlwidgets   1.6.4   2023-12-06 [1] CRAN (R 4.4.0)
 httpuv        1.6.15  2024-03-26 [1] CRAN (R 4.4.0)
 later         1.4.1   2024-11-27 [1] CRAN (R 4.4.1)
 lifecycle     1.0.4   2023-11-07 [1] CRAN (R 4.4.0)
 magrittr      2.0.3   2022-03-30 [1] CRAN (R 4.4.0)
 memoise       2.0.1   2021-11-26 [1] CRAN (R 4.4.0)
 mime          0.12    2021-09-28 [1] CRAN (R 4.4.0)
 miniUI        0.1.1.1 2018-05-18 [1] CRAN (R 4.4.0)
 pillar        1.10.1  2025-01-07 [1] CRAN (R 4.4.1)
 pkgbuild      1.4.5   2024-10-28 [1] CRAN (R 4.4.1)
 pkgconfig     2.0.3   2019-09-22 [1] CRAN (R 4.4.0)
 pkgload       1.4.0   2024-06-28 [1] CRAN (R 4.4.0)
 profvis       0.4.0   2024-09-20 [1] CRAN (R 4.4.1)
 promises      1.3.2   2024-11-28 [1] CRAN (R 4.4.1)
 purrr         1.0.2   2023-08-10 [1] CRAN (R 4.4.0)
 R6            2.5.1   2021-08-19 [1] CRAN (R 4.4.0)
 Rcpp          1.0.14  2025-01-12 [1] CRAN (R 4.4.1)
 remotes       2.5.0   2024-03-17 [1] CRAN (R 4.4.0)
 rlang         1.1.5   2025-01-17 [1] CRAN (R 4.4.1)
 rstudioapi    0.17.1  2024-10-22 [1] CRAN (R 4.4.1)
 sessioninfo   1.2.2   2021-12-06 [1] CRAN (R 4.4.0)
 shiny         1.10.0  2024-12-14 [1] CRAN (R 4.4.1)
 tibble        3.2.1   2023-03-20 [1] CRAN (R 4.4.0)
 tidyselect    1.2.1   2024-03-11 [1] CRAN (R 4.4.0)
 urlchecker    1.0.1   2021-11-30 [1] CRAN (R 4.4.1)
 usethis       3.1.0   2024-11-26 [1] CRAN (R 4.4.1)
 vctrs         0.6.5   2023-12-01 [1] CRAN (R 4.4.0)
 xtable        1.8-4   2019-04-21 [1] CRAN (R 4.4.0)

 [1] /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library
────────────────────────────────────────────────────────────────────────────────────────────────────
```

内容についてご確認頂き、マージして頂ければと思います。
